### PR TITLE
Fix: Resolve 'Error Subscribing' flaky failures in CI tests (#454)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.3.37",
+  "version": "4.3.38",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant issue number (e.g. #404): Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

Meta image changes need to be deployed to be tested since there's nothing to view unless sharing the link with someone else on a social app/site. The only thing we are really testing for is the image fit and other visual factors. These changes should go in with no issues. 
